### PR TITLE
added Feature to import Docsets via the 'openInMenu'

### DIFF
--- a/Dash/DHAppDelegate.h
+++ b/Dash/DHAppDelegate.h
@@ -26,6 +26,4 @@
 + (DHAppDelegate *)sharedDelegate;
 + (UIStoryboard *)mainStoryboard;
 
-
-
 @end

--- a/Dash/DHAppDelegate.h
+++ b/Dash/DHAppDelegate.h
@@ -26,4 +26,6 @@
 + (DHAppDelegate *)sharedDelegate;
 + (UIStoryboard *)mainStoryboard;
 
+
+
 @end

--- a/Dash/DHAppDelegate.m
+++ b/Dash/DHAppDelegate.m
@@ -115,8 +115,8 @@
             [[NSNotificationCenter defaultCenter] postNotificationName:DHPerformURLSearch object:[actualURL absoluteString]];
         });
     }
-	else if([[actualURL pathExtension] caseInsensitiveCompare:@".docset"])
-	{
+    else if([[actualURL pathExtension] caseInsensitiveCompare:@".docset"])
+    {
         NSError *regexError;
         NSString *fileName = [[actualURL URLByDeletingPathExtension] lastPathComponent];
         NSURL *copyToURL = [[NSURL fileURLWithPath:transfersPath] URLByAppendingPathComponent:fileName isDirectory:NO];
@@ -151,7 +151,7 @@
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle: UIAlertControllerStyleAlert];
         [alert addAction:[UIAlertAction actionWithTitle: @"Done" style: UIAlertActionStyleDestructive handler: nil]];
         [[self topViewController] presentViewController: alert animated:YES completion:nil];
-	}
+    }
     else
     {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
@@ -160,7 +160,9 @@
             NSArray *matches;
             if (regexError) {
                 NSLog(@"%@", regexError.localizedDescription);
-            }else{
+            }
+	    else
+	    {
                 matches = [regex matchesInString:[actualURL absoluteString] options:0 range:NSMakeRange(0, [actualURL absoluteString].length)];
             }
             if (matches.count) {

--- a/Dash/DHAppDelegate.m
+++ b/Dash/DHAppDelegate.m
@@ -171,16 +171,16 @@
 		if (error)
 		{
             //Create a UIAlertController to inform the User that the import was not successfull
-            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Import failed!" message:@"Could not properly import the DocSet. Please try again!" preferredStyle: UIAlertControllerStyleAlert];
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Import failed!" message:@"Could not properly import the docset. Please try again!" preferredStyle: UIAlertControllerStyleAlert];
             UIAlertAction *done = [UIAlertAction actionWithTitle: @"Done" style: UIAlertActionStyleDestructive handler: nil];
             [alert addAction:done];
-			NSLog(@"Cannot add file to documentsDirectory");
+            NSLog(@"%@", error.localizedDescription);
             UIViewController *top = [self topViewController];
             [top presentViewController: alert animated:YES completion:nil];
 		}
         else
         {
-            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Import successfull!" message:@"You can find the DocSet in the Transfer Docset Section" preferredStyle: UIAlertControllerStyleAlert];
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Import successfull!" message:@"You can find the docset in the Transfer-Docset section" preferredStyle: UIAlertControllerStyleAlert];
             UIAlertAction *done = [UIAlertAction actionWithTitle: @"Done" style: UIAlertActionStyleDefault handler: nil];
             [alert addAction:done];
             NSLog(@"Docset successfully imported");

--- a/Dash/DHAppDelegate.m
+++ b/Dash/DHAppDelegate.m
@@ -115,6 +115,63 @@
             [[NSNotificationCenter defaultCenter] postNotificationName:DHPerformURLSearch object:[actualURL absoluteString]];
         });
     }
+	else if([[actualURL pathExtension] caseInsensitiveCompare:@".docset"])
+	{
+		//** Code added by Niklas Buelow (@insightmind, twitter: @fforger) for handling files from iCloud (Files.app)'openInMenu' [08.02.2017] **//
+		
+		//declare variable for error
+		NSError *error;
+		
+		//get the path for the DocumentsDirectory
+		NSURL *copyToURL = [NSURL fileURLWithPath:transfersPath];
+		
+		//get the fileName of the URL
+		NSString *fileName = [[actualURL URLByDeletingPathExtension] lastPathComponent];
+		
+		//Add requested file name to path
+		copyToURL = [copyToURL URLByAppendingPathComponent:fileName isDirectory:NO];
+		
+		
+		//check if file is already in DocumentsDirectory
+		if ([[NSFileManager defaultManager] fileExistsAtPath:copyToURL.path])
+		{
+			
+			// Duplicate path
+			NSURL *duplicateURL = copyToURL;
+			// Remove the filename extension
+			copyToURL = [copyToURL URLByDeletingPathExtension];
+			// Filename no extension
+			NSString *fileNameWithoutExtension = [copyToURL lastPathComponent];
+			// File extension
+			NSString *fileExtension = [actualURL pathExtension];
+			
+			int i=1;
+			while ([[NSFileManager defaultManager] fileExistsAtPath:duplicateURL.path]) {
+				
+				// Delete the last path component
+				copyToURL = [copyToURL URLByDeletingLastPathComponent];
+				// Update URL with new name
+				copyToURL=[copyToURL URLByAppendingPathComponent:[NSString stringWithFormat:@"%@–%i",fileNameWithoutExtension,i]];
+				// Add back the file extension
+				copyToURL =[copyToURL URLByAppendingPathExtension:fileExtension];
+				// Copy path to duplicate
+				duplicateURL = copyToURL;
+				i++;
+				
+			}
+		}
+		
+		//Move file to DocumentsDirectory
+		[[NSFileManager defaultManager] moveItemAtURL:actualURL toURL:copyToURL error:&error];
+		
+		//check if an error occurred
+		if (error)
+		{
+			NSLog(@"Cannot add file to documentsDirectory");
+		}
+		
+		//**END**//
+	}
     else
     {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/Dash/DHAppDelegate.m
+++ b/Dash/DHAppDelegate.m
@@ -164,11 +164,29 @@
 		//Move file to DocumentsDirectory
 		[[NSFileManager defaultManager] moveItemAtURL:actualURL toURL:copyToURL error:&error];
 		
+        
+        
+        
 		//check if an error occurred
 		if (error)
 		{
+            //Create a UIAlertController to inform the User that the import was not successfull
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Import failed!" message:@"Could not properly import the DocSet. Please try again!" preferredStyle: UIAlertControllerStyleAlert];
+            UIAlertAction *done = [UIAlertAction actionWithTitle: @"Done" style: UIAlertActionStyleDestructive handler: nil];
+            [alert addAction:done];
 			NSLog(@"Cannot add file to documentsDirectory");
+            UIViewController *top = [self topViewController];
+            [top presentViewController: alert animated:YES completion:nil];
 		}
+        else
+        {
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Import successfull!" message:@"You can find the DocSet in the Transfer Docset Section" preferredStyle: UIAlertControllerStyleAlert];
+            UIAlertAction *done = [UIAlertAction actionWithTitle: @"Done" style: UIAlertActionStyleDefault handler: nil];
+            [alert addAction:done];
+            NSLog(@"Docset successfully imported");
+            UIViewController *top = [self topViewController];
+            [top presentViewController: alert animated:YES completion:nil];
+        }
 		
 		//**END**//
 	}
@@ -344,6 +362,26 @@
             NSLog(@"%@",fileManagerError.localizedDescription);
         }
     }
+}
+
+- (UIViewController *)topViewController{
+    return [self topViewController:[UIApplication sharedApplication].keyWindow.rootViewController];
+}
+
+- (UIViewController *)topViewController:(UIViewController *)rootViewController
+{
+    if (rootViewController.presentedViewController == nil) {
+        return rootViewController;
+    }
+    
+    if ([rootViewController.presentedViewController isKindOfClass:[UINavigationController class]]) {
+        UINavigationController *navigationController = (UINavigationController *)rootViewController.presentedViewController;
+        UIViewController *lastViewController = [[navigationController viewControllers] lastObject];
+        return [self topViewController:lastViewController];
+    }
+    
+    UIViewController *presentedViewController = (UIViewController *)rootViewController.presentedViewController;
+    return [self topViewController:presentedViewController];
 }
 
 @end

--- a/Dash/Dash-Info.plist
+++ b/Dash/Dash-Info.plist
@@ -11,8 +11,12 @@
 		<dict>
 			<key>CFBundleTypeIconFile</key>
 			<string>docset_icon.png</string>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
 			<key>CFBundleTypeName</key>
 			<string>Docset File Type Handler</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
@@ -148,7 +152,29 @@
 			<key>UTTypeTagSpecification</key>
 			<dict>
 				<key>public.filename-extension</key>
-				<string>docset</string>
+				<array>
+					<string>docset</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Docset File Type Handler</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.kapeli.dash.ios.docset</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>docset</string>
+				</array>
 			</dict>
 		</dict>
 	</array>

--- a/Dash/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Dash/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -139,6 +139,11 @@
       "idiom" : "ipad",
       "filename" : "Icon-83.5@2x.png",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Dash/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Dash/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -139,11 +139,6 @@
       "idiom" : "ipad",
       "filename" : "Icon-83.5@2x.png",
       "scale" : "2x"
-    },
-    {
-      "idiom" : "ios-marketing",
-      "size" : "1024x1024",
-      "scale" : "1x"
     }
   ],
   "info" : {


### PR DESCRIPTION
## I added the feature to import Docsets via the 'openInMenu' in iOS.
* Now it is possible to upload a .docset file to iCloud or any other CloudPlatform and import them directly on the iOS device into Dash.
This is especially suitable for use with the iOS11 Files App.

* **It is now also possible to import the Apple API Reference without iTunes File Sharing.**