### PR TITLE
iPhoneX landscape UI issue #76

### DIFF
--- a/Dash/DHBrowserCell.xib
+++ b/Dash/DHBrowserCell.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8121.17" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8101.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,11 +15,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="S6W-09-1z9" id="Ca5-1b-CYh">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="579-AP-FUS" customClass="DHRightDetailLabel">
-                        <rect key="frame" x="46" y="1" width="258" height="43"/>
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="579-AP-FUS" customClass="DHRightDetailLabel">
+                        <rect key="frame" x="46" y="1" width="274" height="43"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/Dash/DHBrowserTableViewCell.m
+++ b/Dash/DHBrowserTableViewCell.m
@@ -52,14 +52,19 @@
 - (void)layoutSubviews
 {
     [super layoutSubviews];
-    if(self.accessoryType == UITableViewCellAccessoryDisclosureIndicator)
-    {
-        [self.titleLabel setFrame:CGRectMake(self.titleLabel.frame.origin.x, self.titleLabel.frame.origin.y, self.frame.size.width-self.titleLabel.frame.origin.x-33, self.titleLabel.frame.size.height)];
-    }
-    else
-    {
-        [self.titleLabel setFrame:CGRectMake(self.titleLabel.frame.origin.x, self.titleLabel.frame.origin.y, self.frame.size.width-self.titleLabel.frame.origin.x-16, self.titleLabel.frame.size.height)];
-    }
+    
+    /* DmytriE 2018-07-21: Constraints are already set in the interface builder.  What is the purpose
+     * of checking whether the right chevron is present?
+     
+        if(self.accessoryType == UITableViewCellAccessoryDisclosureIndicator)
+        {
+            [self.titleLabel setFrame:CGRectMake(self.titleLabel.frame.origin.x, self.titleLabel.frame.origin.y, self.frame.size.width-self.titleLabel.frame.origin.x-33, self.titleLabel.frame.size.height)];
+        }
+        else
+        {
+            [self.titleLabel setFrame:CGRectMake(self.titleLabel.frame.origin.x, self.titleLabel.frame.origin.y, self.frame.size.width-self.titleLabel.frame.origin.x-16, self.titleLabel.frame.size.height)];
+        }
+     */
 }
 
 - (void)insertSubview:(UIView *)view atIndex:(NSInteger)index


### PR DESCRIPTION
In the layoutSubviews method in BrowserTableViewCell.m it generates the frame based on the interface builder with all of the associated constraints there.  The if-else statement below it then modifies the width of the frame from what the constraints.  Thus, uncommenting it and extending the length of the Title Label to the width of the frame resolves this issues.

It functions in iPhone 6, iPhone X, and the plus versions w/ the split screen.